### PR TITLE
Breaking changes in the new ZeroTier controller API

### DIFF
--- a/zerotier/client.go
+++ b/zerotier/client.go
@@ -201,7 +201,7 @@ func (s *ZeroTierClient) headRequest(req *http.Request) (*http.Response, error) 
 
 func (client *ZeroTierClient) CheckNetworkExists(id string) (bool, error) {
 	url := fmt.Sprintf(baseUrl+"/network/%s", id)
-	req, err := http.NewRequest("HEAD", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err
 	}
@@ -350,7 +350,7 @@ func (client *ZeroTierClient) DeleteMember(member *Member) error {
 
 func (client *ZeroTierClient) CheckMemberExists(nwid string, nodeId string) (bool, error) {
 	url := fmt.Sprintf(baseUrl+"/network/%s/member/%s", nwid, nodeId)
-	req, err := http.NewRequest("HEAD", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err
 	}

--- a/zerotier/client.go
+++ b/zerotier/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"strings"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -236,7 +237,7 @@ func (client *ZeroTierClient) GetNetwork(id string) (*Network, error) {
 }
 
 func (client *ZeroTierClient) postNetwork(id string, network *Network) (*Network, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s", id)
+	url := strings.TrimSuffix(fmt.Sprintf(baseUrl+"/network/%s", id), "/")
 	// strip carriage returns?
 	// network.RulesSource = strings.Replace(network.RulesSource, "\r", "", -1)
 	j, err := json.Marshal(network)


### PR DESCRIPTION
Recent changes seem to have broken the provider.

1. The trailing slash for the url redirects to an html page.
2.`HEAD` returns 405, switched it to GET instead