### PR TITLE
 Allow managing DIY Controllers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Use `export ZEROTIER_API_KEY="..."`, or define it in a provider block:
 ```hcl
 provider "zerotier" {
   api_key = "..."
+  
+  ## Optinal: Override for DIY controller
+  ## Could be overriden by ZEROTIER_CONTROLLER_URL env var or this block
+  ## Defaults to https://my.zerotier.com/api when not provided
+  # controller_url = "https://my.zerotier.com/api"
 }
 ```
 

--- a/zerotier/client.go
+++ b/zerotier/client.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 )
 
-const baseUrl string = "https://my.zerotier.com/api"
-
 type ZeroTierClient struct {
-	ApiKey string
+	ApiKey     string
+	Controller string
 }
 
 type Route struct {
@@ -200,7 +199,7 @@ func (s *ZeroTierClient) headRequest(req *http.Request) (*http.Response, error) 
 }
 
 func (client *ZeroTierClient) CheckNetworkExists(id string) (bool, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s", id)
+	url := fmt.Sprintf(client.Controller+"/network/%s", id)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err
@@ -219,7 +218,7 @@ func (client *ZeroTierClient) CheckNetworkExists(id string) (bool, error) {
 }
 
 func (client *ZeroTierClient) GetNetwork(id string) (*Network, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s", id)
+	url := fmt.Sprintf(client.Controller+"/network/%s", id)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -237,7 +236,7 @@ func (client *ZeroTierClient) GetNetwork(id string) (*Network, error) {
 }
 
 func (client *ZeroTierClient) postNetwork(id string, network *Network) (*Network, error) {
-	url := strings.TrimSuffix(fmt.Sprintf(baseUrl+"/network/%s", id), "/")
+	url := strings.TrimSuffix(fmt.Sprintf(client.Controller+"/network/%s", id), "/")
 	// strip carriage returns?
 	// network.RulesSource = strings.Replace(network.RulesSource, "\r", "", -1)
 	j, err := json.Marshal(network)
@@ -275,7 +274,7 @@ func (client *ZeroTierClient) UpdateNetwork(id string, network *Network) (*Netwo
 }
 
 func (client *ZeroTierClient) DeleteNetwork(id string) error {
-	url := fmt.Sprintf(baseUrl+"/network/%s", id)
+	url := fmt.Sprintf(client.Controller+"/network/%s", id)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return err
@@ -289,7 +288,7 @@ func (client *ZeroTierClient) DeleteNetwork(id string) error {
 /////////////
 
 func (client *ZeroTierClient) GetMember(nwid string, nodeId string) (*Member, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s/member/%s", nwid, nodeId)
+	url := fmt.Sprintf(client.Controller+"/network/%s/member/%s", nwid, nodeId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -307,7 +306,7 @@ func (client *ZeroTierClient) GetMember(nwid string, nodeId string) (*Member, er
 }
 
 func (client *ZeroTierClient) postMember(member *Member, reqName string) (*Member, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s/member/%s", member.NetworkId, member.NodeId)
+	url := fmt.Sprintf(client.Controller+"/network/%s/member/%s", member.NetworkId, member.NodeId)
 	j, err := json.Marshal(member)
 	if err != nil {
 		return nil, err
@@ -339,7 +338,7 @@ func (client *ZeroTierClient) UpdateMember(member *Member) (*Member, error) {
 // Careful: this one isn't documented in the Zt API,
 // but this is what the Central web client does.
 func (client *ZeroTierClient) DeleteMember(member *Member) error {
-	url := fmt.Sprintf(baseUrl+"/network/%s/member/%s", member.NetworkId, member.NodeId)
+	url := fmt.Sprintf(client.Controller+"/network/%s/member/%s", member.NetworkId, member.NodeId)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return err
@@ -349,7 +348,7 @@ func (client *ZeroTierClient) DeleteMember(member *Member) error {
 }
 
 func (client *ZeroTierClient) CheckMemberExists(nwid string, nodeId string) (bool, error) {
-	url := fmt.Sprintf(baseUrl+"/network/%s/member/%s", nwid, nodeId)
+	url := fmt.Sprintf(client.Controller+"/network/%s/member/%s", nwid, nodeId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err

--- a/zerotier/provider.go
+++ b/zerotier/provider.go
@@ -1,9 +1,39 @@
 package zerotier
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func isValidControllerURL(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return nil, []error{fmt.Errorf("%q must not be empty", k)}
+	}
+
+	if strings.HasSuffix(trimmed, "/") {
+		return nil, []error{fmt.Errorf("%q should not have trailing slash", k)}
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, []error{fmt.Errorf("%q must be a valid url", k)}
+	}
+
+	if parsed.Scheme == "" {
+		return nil, []error{fmt.Errorf("%q should have an scheme, such as http:// or https://", k)}
+	}
+
+	return nil, nil
+}
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
@@ -12,6 +42,12 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ZEROTIER_API_KEY", nil),
+			},
+			"controller_url": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				DefaultFunc:  schema.EnvDefaultFunc("ZEROTIER_CONTROLLER_URL", "https://my.zerotier.com/api"),
+				ValidateFunc: isValidControllerURL,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -23,5 +59,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
-	return &ZeroTierClient{ApiKey: d.Get("api_key").(string)}, nil
+	return &ZeroTierClient{
+		ApiKey:     d.Get("api_key").(string),
+		Controller: d.Get("controller_url").(string)}, nil
 }


### PR DESCRIPTION
Zerotier provides a central controller on https://my.zerotier.com
and it is possible to run our own DIY controller if we desire as well.

Currently, this provider uses a hardcoded string pointing to the central
controller, which don't allow changes by downstream users.

This changes allow overriding the controller url on the provider itself,
with default falling back over to the central controller, including
documentation changes on `README`.