### PR TITLE
Avoid diffs due to order of elements returned by the controller 

### DIFF
--- a/zerotier/resource_zerotier_member.go
+++ b/zerotier/resource_zerotier_member.go
@@ -68,7 +68,7 @@ func resourceZeroTierMember() *schema.Resource {
 				},
 			},
 			"capabilities": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
@@ -143,7 +143,7 @@ func memberFromResourceData(d *schema.ResourceData) (*Member, error) {
 		}
 		tagTuples = append(tagTuples, []int{i, val.(int)})
 	}
-	capsRaw := d.Get("capabilities").([]interface{})
+	capsRaw := d.Get("capabilities").(*schema.Set).List()
 	caps := make([]int, len(capsRaw))
 	for i := range capsRaw {
 		caps[i] = capsRaw[i].(int)

--- a/zerotier/resource_zerotier_network.go
+++ b/zerotier/resource_zerotier_network.go
@@ -63,7 +63,7 @@ func resourceZeroTierNetwork() *schema.Resource {
 				Default:  true,
 			},
 			"route": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     route(),
 			},
@@ -113,7 +113,7 @@ func resourceNetworkExists(d *schema.ResourceData, m interface{}) (b bool, e err
 }
 
 func fromResourceData(d *schema.ResourceData) (*Network, error) {
-	routesRaw := d.Get("route").([]interface{})
+	routesRaw := d.Get("route").(*schema.Set).List()
 	var routes []Route
 	for _, raw := range routesRaw {
 		r := raw.(map[string]interface{})


### PR DESCRIPTION
The network and member resource use a couple of settings which could be
defined multiple times.

For example: the assigned ips on a member could change the order, while
the semantic means the same.

The provider was using a `schema.ListType`, which according to the
documentation is an *ordered* list of elements, where the order
matter.

On those resource seetings, the order is not relevant, as they are
sematically equivalent. There is a `schema.SetType` which provides an
*unordered* collection of settings, and grants the same order given the
same settings.

This commit changes the schema of those resources to use
`schema.SetType` instead of `schema.ListType` to avoid diff loops
depending on the sorting of the response from the API.