### PR TITLE
Exposes broadcast and multicast settings on Network 

### DIFF
--- a/zerotier/client.go
+++ b/zerotier/client.go
@@ -35,6 +35,8 @@ type V4AssignModeConfig struct {
 type Config struct {
 	Name              string             `json:"name"`
 	Private           bool               `json:"private"`
+	EnableBroadcast   bool               `json:"enableBroadcast"`
+	MulticastLimit    int                `json:"multicastLimit"`
 	Routes            []Route            `json:"routes"`
 	IpAssignmentPools []IpRange          `json:"ipAssignmentPools"`
 	V4AssignMode      V4AssignModeConfig `json:"v4AssignMode"`

--- a/zerotier/resource_zerotier_network.go
+++ b/zerotier/resource_zerotier_network.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func route() *schema.Resource {
@@ -61,6 +62,20 @@ func resourceZeroTierNetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			//Warning: Undecoumented on the API, but that is how the UI manages it
+			"broadcast": &schema.Schema{
+				Type:        schema.TypeBool,
+				Description: "Enable network broadcast (ff:ff:ff:ff:ff:ff)",
+				Optional:    true,
+				Default:     true,
+			},
+			"multicast_limit": &schema.Schema{
+				Type:         schema.TypeInt,
+				Description:  "The maximum number of recipients that can receive an Ethernet multicast or broadcast. Setting to 0 disables multicast, but be aware that only IPv6 with NDP emulation (RFC4193 or 6PLANE addressing modes) or other unicast-only protocols will work without multicast.",
+				Optional:     true,
+				Default:      32,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 			"route": &schema.Schema{
 				Type:     schema.TypeList,
@@ -144,6 +159,8 @@ func fromResourceData(d *schema.ResourceData) (*Network, error) {
 		Config: &Config{
 			Name:              d.Get("name").(string),
 			Private:           d.Get("private").(bool),
+			EnableBroadcast:   d.Get("broadcast").(bool),
+			MulticastLimit:    d.Get("multicast_limit").(int),
 			V4AssignMode:      V4AssignModeConfig{ZT: true},
 			Routes:            routes,
 			IpAssignmentPools: pools,
@@ -186,6 +203,8 @@ func resourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", net.Config.Name)
 	d.Set("description", net.Description)
 	d.Set("private", net.Config.Private)
+	d.Set("broadcast", net.Config.EnableBroadcast)
+	d.Set("multicast_limit", net.Config.MulticastLimit)
 	d.Set("auto_assign_v4", net.Config.V4AssignMode.ZT)
 	d.Set("rules_source", net.RulesSource)
 


### PR DESCRIPTION
There was a few settings on the network that are exposed on the ZeroTier
Central UI which were not available on the provider.

This commit includes those extra fields, where one of them are not
documented but available on the UI.