### PR TITLE
Typo in Makefile referencing darwin archive on linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ copy-mac:
 copy-linux:
 	rm -f bin/terraform-provider-zerotier
 	mkdir -p "${HOME}/.terraform.d/plugins/linux_amd64"
-	tar -xvf bin/terraform-provider-zerotier_darwin-amd64_$(TAG).tgz && \
+	tar -xvf bin/terraform-provider-zerotier_linux-amd64_$(TAG).tgz && \
 		mv bin/terraform-provider-zerotier_$(TAG) "${HOME}/.terraform.d/plugins/linux_amd64/"
 
 copy-windows:


### PR DESCRIPTION
Linux build ( see below ) references wrong file.

$ make install
GOOS=linux GOARCH=amd64 go build -o bin/terraform-provider-zerotier_v0.2.0
tar czvf bin/terraform-provider-zerotier_linux-amd64_v0.2.0.tgz bin/terraform-provider-zerotier_v0.2.0
bin/terraform-provider-zerotier_v0.2.0
rm -rf bin/terraform-provider-zerotier_v0.2.0
rm -f bin/terraform-provider-zerotier
mkdir -p "/home/x/.terraform.d/plugins/linux_amd64"
tar -xvf bin/terraform-provider-zerotier_darwin-amd64_v0.2.0.tgz && \
	mv bin/terraform-provider-zerotier_v0.2.0 "/home/x/.terraform.d/plugins/linux_amd64/"
tar: bin/terraform-provider-zerotier_darwin-amd64_v0.2.0.tgz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
make: *** [Makefile:46: copy-linux] Error 2
